### PR TITLE
Adjust non-modal selected menu item background

### DIFF
--- a/styles/select-list.less
+++ b/styles/select-list.less
@@ -5,7 +5,7 @@
 
 :not(.modal) .select-list .list-group {
   li.selected {
-    background: mix(@select-list-selected-background, #707070);
+    background: lighten(@select-list-selected-background, 10%);
   }
 }
 

--- a/styles/select-list.less
+++ b/styles/select-list.less
@@ -12,3 +12,9 @@
     text-shadow: @select-list-selected-shadow;
   }
 }
+
+:not(.modal) .select-list .list-group {
+  li.selected {
+    background: mix(@select-list-selected-background, #707070);
+  }
+}

--- a/styles/select-list.less
+++ b/styles/select-list.less
@@ -1,6 +1,4 @@
 
-@import "ui-variables.less";
-
 @select-list-selected-text-color: @text-color-selected;
 @select-list-selected-background: rgba(50, 52, 60, 0.7);
 @select-list-selected-shadow: 0px 0px 2px @text-color-selected;

--- a/styles/select-list.less
+++ b/styles/select-list.less
@@ -5,16 +5,16 @@
 @select-list-selected-background: rgba(50, 52, 60, 0.7);
 @select-list-selected-shadow: 0px 0px 2px @text-color-selected;
 
+:not(.modal) .select-list .list-group {
+  li.selected {
+    background: mix(@select-list-selected-background, #707070);
+  }
+}
+
 .modal .select-list .list-group {
   li.selected {
     color: @select-list-selected-text-color;
     background-color: @select-list-selected-background;
     text-shadow: @select-list-selected-shadow;
-  }
-}
-
-:not(.modal) .select-list .list-group {
-  li.selected {
-    background: mix(@select-list-selected-background, #707070);
   }
 }


### PR DESCRIPTION
I found that non-modal menu-list (such as autocomplete suggestion list) needs to be highlighten, too. But if I apply css attributes in [my previous PR](https://github.com/v3ss0n/steam-pirate-ui/pull/4), it looks terrible, so I make one for `:not(.modal)`.

Check this out
![image](https://cloud.githubusercontent.com/assets/11488886/18814868/985622ee-8349-11e6-80a2-cf0820b1f3d7.png)
