### PR TITLE
Stop deprecation warnings.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
   "main": "lib/settings",
   "repository": "https://github.com/v3ss0n/steam-pirate-ui",
   "engines": {
-    "atom": ">0.40.0"
+    "atom": "1.13.0 <2.0.0"
   }
 }

--- a/styles/editor.less
+++ b/styles/editor.less
@@ -5,7 +5,7 @@ atom-text-editor[mini] {
   overflow: auto;
 }
 atom-text-editor,
-:host{
+editor {
   background-color: @app-background-color;
 }
 
@@ -14,7 +14,7 @@ atom-text-editor,
   background-color:  transparent ;
 }
 atom-text-editor,
-atom-text-editor::shadow {
+atom-text-editor.editor {
   .scroll-view {
   background-color:   @app-background-color !important ;
   
@@ -40,7 +40,7 @@ atom-text-editor[mini] {
   padding-left: @ui-padding/2;
 
   &,
-  &::shadow {
+  &.editor {
     .placeholder-text {
       color: @text-color-subtle;
     }
@@ -54,7 +54,7 @@ atom-text-editor[mini] {
   }
 
   &.is-focused,
-  &.is-focused::shadow {
+  &.is-focused.editor {
     .focus();
     background-color: @input-background-color-focus;
     .selection .region {

--- a/styles/packages.less
+++ b/styles/packages.less
@@ -121,7 +121,7 @@
     background-clip: padding-box;
   }
 
-  atom-text-editor::shadow {
+  atom-text-editor.editor {
     .line.cursor-line {
       background-color: transparent;
     }


### PR DESCRIPTION
* Changed the versions of Atom that are supported in `package.json`. 
* Edited the styles files as suggested by the deprecation warning that was shown in #8, #9 and #10.

**WARNING**: This is my first attempt at doing anything with Atom UI but I really like this theme and wanted to stop the deprecation warnings.  Apologies if it isn't the best way of doing this.